### PR TITLE
Fixed umount error when the parent was the bind mount point

### DIFF
--- a/src/Win_GParted.cc
+++ b/src/Win_GParted.cc
@@ -2845,7 +2845,7 @@ bool Win_GParted::unmount_partition( const Partition & partition, Glib::ustring 
 			// a case to write such complicated code for.
 			skipped_mountpoints.push_back( fs_mountpoints[i] );
 		}
-		else
+		else if ( i == ( fs_mountpoints.size() - 1) )
 		{
 			Glib::ustring cmd = "umount -v " + Glib::shell_quote( fs_mountpoints[i] );
 			Glib::ustring dummy;


### PR DESCRIPTION
The test steps are as follows：

1. Have a  bind mount point,like this
```
# /dev/sda4
UUID=xxxx      /data           xfs             rw,relatime,attr2,inode64,sunit=128,swidth=256,noquota  0 2
/data/home /home none defaults,bind 0 0
```
2. Mount the disk to the subdirectory of the bind mount point，like this
`mount /dev/sdb  /home/test `

3. Open the GParted graphics tool and umount `/dev/sdb`
4. An error message will be displayed:
```
#umount -v '/home/test'
umount: /home/test: not mounted.
```

In bind mode, the gparted tool displays two mount points: `/data/home/test` and `/home/test`.

During the unmounting, two mount points will be umount in a circular manner. After the first mount point is successfully unmounted, the second mount point fails to be unmounted.

